### PR TITLE
Fixing phpstan file to analyse only project files

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
 	autoload_files:
-		- vendor/bin/.phpunit/phpunit-6.5/vendor/autoload.php
-	ignoreErrors:
-		# Intended
-		- '#Parameter \#1 \$topics of class Symfony\\Component\\Mercure\\Update constructor expects array\|string, int given\.#'
-
+		- vendor/autoload.php
+	excludes_analyse:
+		- %currentWorkingDirectory%/tests
+		- %currentWorkingDirectory%/vendor


### PR DESCRIPTION
I saw strange paths and `ignoreErrors` in `phpstan.neon` so I had to take a look.

This won't work if level > 3 since `Update::__construct` has `$topics` type-hinted and following `if` statement can't be `true` with current type-hint.