### PR TITLE
Pass target to the jwt_provider

### DIFF
--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -52,7 +52,7 @@ final class Publisher implements PublisherInterface
             'retry' => $update->getRetry(),
         ];
 
-        $jwt = ($this->jwtProvider)();
+        $jwt = ($this->jwtProvider)($update->getTargets());
         $this->validateJwt($jwt);
 
         return $this->httpClient->request('POST', $this->hubUrl, [

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -52,7 +52,7 @@ final class Publisher implements PublisherInterface
             'retry' => $update->getRetry(),
         ];
 
-        $jwt = ($this->jwtProvider)($update->getTargets());
+        $jwt = ($this->jwtProvider)($update);
         $this->validateJwt($jwt);
 
         return $this->httpClient->request('POST', $this->hubUrl, [


### PR DESCRIPTION
What do you think about passing target to the JWT Provider.
In fact the target need the target to be in the JWT Token when mercure is private and to send to specific target.

Then we can generate a JWT Token via 
```
mercure:
    enable_profiler: "%kernel.debug%"
    hubs:
        default:
            url: "%env(MERCURE_PUBLISH_URL)%"
            jwt_provider: App\Mercure\MyJwtProvider 
```

```
<?php 

namespace App\Mercure;

use App\Security\Mercure\JWTMercureToken;


final class MyJwtProvider
{
    private $JWTMercureToken;

    public function __construct(JWTMercureToken $JWTMercureToken) {
        $this->JWTMercureToken = $JWTMercureToken;
    }

    public function __invoke(array $target): string
    {
        return $this->JWTMercureToken->getPublisherMercureJWT($target);
    }
}
```

```

    public function getPublisherMercureJWT(array $publish = []): string
    {
        $token = (new Builder())
            ->withClaim('mercure', ['publish' => $publish])
            ->getToken(new Sha256(), new Key($this->container->getParameter('mercure_secret_key')));

        return $token;
       
    }
```

What do you think ?