### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jobs:
       env: lint=1
     - php: '7.4'
       env: deps=low
+    - php: '8.0snapshot'
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "symfony/http-client": "^4.3.5|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
php-build doesn't support pre-releases (yet), this is what travis uses to build the php environment. With `8.0snapshot` you can get a pre-release, but maybe wait until PHP 8 is GA. 