### PR TITLE
[feature] add token factory, token provider, and messenger handler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ jobs:
     - php: '7.2'
     - php: '7.3'
     - php: '7.4'
-      env: lint=1
+      env:
+        - lint=1
+        - test_jwt=yes
     - php: '7.4'
-      env: deps=low
-    - php: '8.0snapshot'
+      env:
+        - deps=low
+        - test_jwt=yes
+    - php: '8.0'
+      env:
+        - test_jwt=yes
 
 cache:
   directories:
@@ -23,6 +29,10 @@ before_script:
   - phpenv config-rm xdebug.ini
 
 install:
+  - if [[ $test_jwt != 'yes' ]]; then
+      composer remove --no-update --dev lcobucci/jwt;
+    fi
+
   - if [[ $deps = 'low' ]]; then
       composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi;
     else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 CHANGELOG
 =========
 
+0.5.0
+-----
+
+* added `Symfony\Component\Mercure\Jwt\TokenProviderInterface`
+* added `Symfony\Component\Mercure\Jwt\TokenFactoryInterface`
+* added `Symfony\Component\Mercure\Jwt\StaticTokenProvider`
+* added `Symfony\Component\Mercure\Jwt\CallabkeTokenProvider`
+* added `Symfony\Component\Mercure\Jwt\LcobucciTokenFactory`
+* added `Symfony\Component\Mercure\Jwt\FactoryTokenProvider`
+* added `Symfony\Component\Mercure\Messenger\UpdateHandler`
+* added `Symfony\Component\Mercure\Hub`
+* deprecated `Jwt\StaticJwtProvider`, use `Jwt\StaticTokenProvider` instead.
+* deprecated passing a url and a callable jwt provider to `Publisher::__construct`, pass a `Hub` instance instead.
+* deprecated `PublisherInterface::__invoke` method in favor of `PublisherInterface::publish`.
+
 0.4.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ $ composer require symfony/mercure
 define('HUB_URL', 'https://demo.mercure.rocks/.well-known/mercure');
 define('JWT', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM');
 
-use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
+use Symfony\Component\Mercure\Hub;
 use Symfony\Component\Mercure\Publisher;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Update;
 
-$publisher = new Publisher(HUB_URL, new StaticJwtProvider(JWT));
+$hub = new Hub(HUB_URL, new StaticTokenProvider(JWT));
+$publisher = new Publisher($hub);
 // Serialize the update, and dispatch it to the hub, that will broadcast it to the clients
-$id = $publisher(new Update('https://example.com/books/1.jsonld', 'Hi from Symfony!'));
+$id = $publisher->publish(new Update('https://example.com/books/1.jsonld', 'Hi from Symfony!'));
 ```
 
 Resources

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/http-client": "^4.3.5|^5.0"
+        "symfony/http-client": "^4.3.5|^5.0",
+        "symfony/deprecation-contracts": "^2.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mercure\\": "src/" }
@@ -41,6 +42,7 @@
         "symfony/stopwatch": "Integration with the profiler performances"
     },
     "require-dev": {
+        "lcobucci/jwt": "^4.0",
         "symfony/phpunit-bridge": "^4.2.4|^5.0",
         "symfony/stopwatch": "^4.3|^5.0"
     },

--- a/src/Debug/TraceablePublisher.php
+++ b/src/Debug/TraceablePublisher.php
@@ -39,9 +39,20 @@ final class TraceablePublisher implements PublisherInterface, ResetInterface
 
     public function __invoke(Update $update): string
     {
+        trigger_deprecation('symfony/mercure', '0.5', 'Method "%s()" is deprecated, use "%s::publish()" instead.', __METHOD__, __CLASS__);
+
+        return $this->publish($update);
+    }
+
+    public function publish(Update $update): string
+    {
         $this->stopwatch->start(__CLASS__);
 
-        $content = ($this->publisher)($update);
+        if (method_exists($this->publisher, 'publish')) {
+            $content = $this->publisher->publish($update);
+        } else {
+            $content = ($this->publisher)($update);
+        }
 
         $e = $this->stopwatch->stop(__CLASS__);
         $this->messages[] = [
@@ -53,7 +64,7 @@ final class TraceablePublisher implements PublisherInterface, ResetInterface
         return $content;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->messages = [];
     }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Exception;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Exception;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+    /**
+     * @param string[] $supportedAlgorithms
+     */
+    public static function forInvalidAlgorithm(string $algorithm, array $supportedAlgorithms): self
+    {
+        return new self(sprintf('Unsupported algorithm "%s", expected one of "%s".', $algorithm, implode('", "', $supportedAlgorithms)));
+    }
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Exception;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Hub.php
+++ b/src/Hub.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure;
+
+use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class Hub
+{
+    private $url;
+    private $jwtProvider;
+
+    public function __construct(string $url, TokenProviderInterface $jwtProvider)
+    {
+        $this->url = $url;
+        $this->jwtProvider = $jwtProvider;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getProvider(): TokenProviderInterface
+    {
+        return $this->jwtProvider;
+    }
+}

--- a/src/Internal/QueryBuilder.php
+++ b/src/Internal/QueryBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Internal;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @internal
+ */
+final class QueryBuilder
+{
+    public static function build(array $data): string
+    {
+        $parts = [];
+        foreach ($data as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            if (\is_array($value)) {
+                foreach ($value as $v) {
+                    $parts[] = self::encode($key, $v);
+                }
+
+                continue;
+            }
+
+            $parts[] = self::encode($key, $value);
+        }
+
+        return implode('&', $parts);
+    }
+
+    private static function encode($key, $value): string
+    {
+        // All Mercure's keys are safe, so don't need to be encoded, but it's not a generic solution
+        return sprintf('%s=%s', $key, urlencode((string) $value));
+    }
+}

--- a/src/Jwt/CallableTokenProvider.php
+++ b/src/Jwt/CallableTokenProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class CallableTokenProvider implements TokenProviderInterface
+{
+    private $provider;
+
+    /**
+     * @param (callable(): string) $provider
+     */
+    public function __construct(callable $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function getJwt(): string
+    {
+        return ($this->provider)();
+    }
+}

--- a/src/Jwt/FactoryTokenProvider.php
+++ b/src/Jwt/FactoryTokenProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class FactoryTokenProvider implements TokenProviderInterface
+{
+    private $factory;
+    private $publish;
+    private $subscribe;
+
+    public function __construct(TokenFactoryInterface $factory, array $publish, array $subscribe)
+    {
+        $this->factory = $factory;
+        $this->publish = $publish;
+        $this->subscribe = $subscribe;
+    }
+
+    public function getJwt(): string
+    {
+        return $this->factory->create($this->publish, $this->subscribe);
+    }
+}

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Token\RegisteredClaims;
+use Symfony\Component\Mercure\Exception\InvalidArgumentException;
+
+if (!class_exists(Key\InMemory::class)) {
+    throw new \LogicException('You cannot use "Symfony\Component\Mercure\Token\LcobucciFactory" as the "lcobucci/jwt" package is not installed. Try running "composer require lcobucci/jwt".');
+}
+
+final class LcobucciFactory implements TokenFactoryInterface
+{
+    /**
+     * @var array<string, class-string<Signer>>
+     */
+    public const SIGN_ALGORITHMS = [
+        'hmac.sha256' => Signer\Hmac\Sha256::class,
+        'hmac.sha384' => Signer\Hmac\Sha384::class,
+        'hmac.sha512' => Signer\Hmac\Sha512::class,
+        'ecdsa.sha256' => Signer\Ecdsa\Sha256::class,
+        'ecdsa.sha384' => Signer\Ecdsa\Sha384::class,
+        'ecdsa.sha512' => Signer\Ecdsa\Sha512::class,
+        'rsa.sha256' => Signer\Rsa\Sha256::class,
+        'rsa.sha384' => Signer\Rsa\Sha384::class,
+        'rsa.sha512' => Signer\Rsa\Sha512::class,
+    ];
+
+    private $configurations;
+
+    public function __construct(string $secret, string $algorithm = 'hmac.sha256')
+    {
+        if (!\array_key_exists($algorithm, self::SIGN_ALGORITHMS)) {
+            throw InvalidArgumentException::forInvalidAlgorithm($algorithm, \array_keys(self::SIGN_ALGORITHMS));
+        }
+
+        $signerClass = self::SIGN_ALGORITHMS[$algorithm];
+        $this->configurations = Configuration::forSymmetricSigner(
+            new $signerClass(),
+            Key\InMemory::plainText($secret)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $publish, array $subscribe, array $additionalClaims = []): string
+    {
+        $builder = $this->configurations->builder();
+
+        $additionalClaims['mercure'] = [
+            'publish' => $publish,
+            'subscribe' => $subscribe,
+        ];
+
+        foreach ($additionalClaims as $name => $value) {
+            switch ($name) {
+                case RegisteredClaims::AUDIENCE:
+                    $builder = $builder->permittedFor(...(array) $value);
+                    break;
+                case RegisteredClaims::EXPIRATION_TIME:
+                    $builder = $builder->expiresAt($value);
+                    break;
+                case RegisteredClaims::ISSUED_AT:
+                    $builder = $builder->issuedAt($value);
+                    break;
+                case RegisteredClaims::ISSUER:
+                    $builder = $builder->issuedBy($value);
+                    break;
+                case RegisteredClaims::SUBJECT:
+                    $builder = $builder->relatedTo($value);
+                    break;
+                case RegisteredClaims::ID:
+                    $builder = $builder->identifiedBy($value);
+                    break;
+                case RegisteredClaims::NOT_BEFORE:
+                    $builder = $builder->canOnlyBeUsedAfter($value);
+                    break;
+                default:
+                    $builder = $builder->withClaim($name, $value);
+            }
+        }
+
+        return $builder
+            ->getToken($this->configurations->signer(), $this->configurations->signingKey())
+            ->toString();
+    }
+}

--- a/src/Jwt/StaticJwtProvider.php
+++ b/src/Jwt/StaticJwtProvider.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Mercure\Jwt;
 
+trigger_deprecation('symfony/mercure', '0.5', 'Class "%s" is deprecated, use "%s" instead.', StaticJwtProvider::class, StaticTokenProvider::class);
+
 /**
  * Provides a JWT passed as a configuration parameter.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
  * @experimental
+ *
+ * @deprecated
  */
 final class StaticJwtProvider
 {

--- a/src/Jwt/StaticTokenProvider.php
+++ b/src/Jwt/StaticTokenProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class StaticTokenProvider implements TokenProviderInterface
+{
+    private $token;
+
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getJwt(): string
+    {
+        return $this->token;
+    }
+}

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+interface TokenFactoryInterface
+{
+    /**
+     * Create a token that allows publishing to $publish and subscribing to $subscribe.
+     *
+     * @param string[] $publish          a list of topics that the token will allow publishing to
+     * @param string[] $subscribe        a list of topics that the token will allow subscribing to
+     * @param mixed[]  $additionalClaims an array of additional claims for the JWT
+     */
+    public function create(array $publish, array $subscribe, array $additionalClaims = []): string;
+}

--- a/src/Jwt/TokenProviderInterface.php
+++ b/src/Jwt/TokenProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Jwt;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+interface TokenProviderInterface
+{
+    public function getJwt(): string;
+}

--- a/src/Messenger/UpdateHandler.php
+++ b/src/Messenger/UpdateHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Messenger;
+
+use Symfony\Component\Mercure\PublisherInterface;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ *
+ * @experimental
+ */
+final class UpdateHandler
+{
+    private $publisher;
+
+    public function __construct(PublisherInterface $publisher)
+    {
+        $this->publisher = $publisher;
+    }
+
+    public function __invoke(Update $update): void
+    {
+        if (method_exists($this->publisher, 'publish')) {
+            $this->publisher->publish($update);
+        } else {
+            ($this->publisher)($update);
+        }
+    }
+}

--- a/src/PublisherInterface.php
+++ b/src/PublisherInterface.php
@@ -17,8 +17,13 @@ namespace Symfony\Component\Mercure;
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  *
  * @experimental
+ *
+ * @method string publish(Update $update)
  */
 interface PublisherInterface
 {
+    /**
+     * @deprecated since 0.5, use {@see PublisherInterface::publish} instead.
+     */
     public function __invoke(Update $update): string;
 }

--- a/tests/Jwt/FactoryTokenProviderTest.php
+++ b/tests/Jwt/FactoryTokenProviderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Tests\Jwt;
+
+use Lcobucci\JWT\Signer\Key;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mercure\Jwt\FactoryTokenProvider;
+use Symfony\Component\Mercure\Jwt\LcobucciFactory;
+
+final class FactoryTokenProviderTest extends TestCase
+{
+    public function testGetToken(): void
+    {
+        if (!class_exists(Key\InMemory::class)) {
+            $this->markTestSkipped('requires lcobucci/jwt:^4.0.');
+        }
+
+        $factory = new LcobucciFactory('!ChangeMe!');
+        $provider = new FactoryTokenProvider($factory, ['*'], []);
+
+        $this->assertSame(
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',
+            $provider->getJwt()
+        );
+    }
+}

--- a/tests/Jwt/LcobucciFactoryTest.php
+++ b/tests/Jwt/LcobucciFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Tests\Jwt;
+
+use Lcobucci\JWT\Signer\Key;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mercure\Exception\InvalidArgumentException;
+use Symfony\Component\Mercure\Jwt\LcobucciFactory;
+
+final class LcobucciFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(Key\InMemory::class)) {
+            $this->markTestSkipped('requires lcobucci/jwt:^4.0.');
+        }
+    }
+
+    public function testCreate(): void
+    {
+        $factory = new LcobucciFactory('!ChangeMe!');
+
+        $this->assertSame(
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',
+            $factory->create(['*'], [])
+        );
+    }
+
+    public function testInvalidAlgorithm(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported algorithm "md5", expected one of "hmac.sha256", "hmac.sha384", "hmac.sha512", "ecdsa.sha256", "ecdsa.sha384", "ecdsa.sha512", "rsa.sha256", "rsa.sha384", "rsa.sha512".');
+
+        new LcobucciFactory('!ChangeMe!', 'md5');
+    }
+}

--- a/tests/Jwt/StaticTokenProviderTest.php
+++ b/tests/Jwt/StaticTokenProviderTest.php
@@ -14,15 +14,15 @@ declare(strict_types=1);
 namespace Symfony\Component\Mercure\Tests\Jwt;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 
-class StaticJwtProviderTest extends TestCase
+class StaticTokenProviderTest extends TestCase
 {
     const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtZXJjdXJlLXRlc3QiLCJuYW1lIjoiS8OpdmluIER1bmdsYXMiLCJpYXQiOjE1MTYyMzkwMjJ9.n0KvJ31TCswaK7KuHiN22cLzpjC2UT2rhWqhIDprfmA';
 
-    public function testProvider()
+    public function testGetToken()
     {
-        $provider = new StaticJwtProvider(self::JWT);
-        $this->assertSame(self::JWT, $provider());
+        $provider = new StaticTokenProvider(self::JWT);
+        $this->assertSame(self::JWT, $provider->getJwt());
     }
 }

--- a/tests/Messenger/UpdateHandlerTest.php
+++ b/tests/Messenger/UpdateHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Tests\Messenger;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mercure\Hub;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
+use Symfony\Component\Mercure\Messenger\UpdateHandler;
+use Symfony\Component\Mercure\Publisher;
+use Symfony\Component\Mercure\Update;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class UpdateHandlerTest extends TestCase
+{
+    const URL = 'https://demo.mercure.rocks/.well-known/mercure';
+    const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyIqIl0sInB1Ymxpc2giOlsiKiJdfX0.M1yJUov4a6oLrigTqBZQO_ohWUsg3Uz1bnLD4MIyWLo';
+    const AUTH_HEADER = 'Authorization: Bearer '.self::JWT;
+
+    public function testInvoke()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame(self::URL, $url);
+            $this->assertSame(self::AUTH_HEADER, $options['normalized_headers']['authorization'][0]);
+            $this->assertSame('topic=https%3A%2F%2Fdemo.mercure.rocks%2Fdemo%2Fbooks%2F1.jsonld&data=Hi+from+Symfony%21&private=on&id=id&retry=3', $options['body']);
+
+            return new MockResponse('id');
+        });
+
+        $provider = new StaticTokenProvider(self::JWT);
+        $hub = new Hub(self::URL, $provider);
+        $publisher = new Publisher($hub, $httpClient);
+        $handler = new UpdateHandler($publisher);
+
+        $handler(new Update(
+            'https://demo.mercure.rocks/demo/books/1.jsonld',
+            'Hi from Symfony!',
+            true,
+            'id',
+            null,
+            3
+        ));
+    }
+}

--- a/tests/PublisherTest.php
+++ b/tests/PublisherTest.php
@@ -14,8 +14,14 @@ declare(strict_types=1);
 namespace Symfony\Component\Mercure\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mercure\Exception\InvalidArgumentException;
+use Symfony\Component\Mercure\Exception\RuntimeException;
+use Symfony\Component\Mercure\Hub;
+use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Publisher;
 use Symfony\Component\Mercure\Update;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -31,10 +37,6 @@ class PublisherTest extends TestCase
 
     public function testPublish()
     {
-        $jwtProvider = function (): string {
-            return self::JWT;
-        };
-
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame(self::URL, $url);
@@ -44,32 +46,86 @@ class PublisherTest extends TestCase
             return new MockResponse('id');
         });
 
-        // Set $httpClient to null to dispatch a real update through the demo hub
-        $publisher = new Publisher(self::URL, $jwtProvider, $httpClient);
-        $id = $publisher(
-            new Update(
-                'https://demo.mercure.rocks/demo/books/1.jsonld',
-                'Hi from Symfony!',
-                true,
-                'id',
-                null,
-                3
-            )
-        );
+        $provider = new StaticTokenProvider(self::JWT);
+        $hub = new Hub(self::URL, $provider);
+        $publisher = new Publisher($hub, $httpClient);
+        $id = $publisher->publish(new Update(
+            'https://demo.mercure.rocks/demo/books/1.jsonld',
+            'Hi from Symfony!',
+            true,
+            'id',
+            null,
+            3
+        ));
 
         $this->assertSame('id', $id);
     }
 
+    /**
+     * @group legacy
+     */
+    public function testPublishLegacy()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame(self::URL, $url);
+            $this->assertSame(self::AUTH_HEADER, $options['normalized_headers']['authorization'][0]);
+            $this->assertSame('topic=https%3A%2F%2Fdemo.mercure.rocks%2Fdemo%2Fbooks%2F1.jsonld&data=Hi+from+Symfony%21&private=on&id=id&retry=3', $options['body']);
+
+            return new MockResponse('id');
+        });
+
+        // @phpstan-ignore-next-line
+        $publisher = new Publisher(self::URL, new StaticJwtProvider(self::JWT), $httpClient);
+        $id = $publisher(new Update(
+            'https://demo.mercure.rocks/demo/books/1.jsonld',
+            'Hi from Symfony!',
+            true,
+            'id',
+            null,
+            3
+        ));
+
+        $this->assertSame('id', $id);
+    }
+
+    public function testNetworkIssue()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame(self::URL, $url);
+            $this->assertSame(self::AUTH_HEADER, $options['normalized_headers']['authorization'][0]);
+            $this->assertSame('topic=https%3A%2F%2Fdemo.mercure.rocks%2Fdemo%2Fbooks%2F1.jsonld&data=Hi+from+Symfony%21&private=on&id=id&retry=3', $options['body']);
+
+            throw new TransportException('Ops');
+        });
+
+        $provider = new StaticTokenProvider(self::JWT);
+        $hub = new Hub(self::URL, $provider);
+        $publisher = new Publisher($hub, $httpClient);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to send an update.');
+
+        $publisher->publish(new Update(
+            'https://demo.mercure.rocks/demo/books/1.jsonld',
+            'Hi from Symfony!',
+            true,
+            'id',
+            null,
+            3
+        ));
+    }
+
     public function testInvalidJwt()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The provided JWT is not valid');
 
-        $jwtProvider = function (): string {
-            return "invalid\r\njwt";
-        };
+        $provider = new StaticTokenProvider("invalid\r\njwt");
+        $hub = new Hub(self::URL, $provider);
+        $publisher = new Publisher($hub);
 
-        $publisher = new Publisher(self::URL, $jwtProvider);
-        $publisher(new Update('https://demo.mercure.rocks/demo/books/1.jsonld', 'Hi from Symfony!'));
+        $publisher->publish(new Update('https://demo.mercure.rocks/demo/books/1.jsonld', 'Hi from Symfony!'));
     }
 }


### PR DESCRIPTION
changelog:

### features:

- added `Jwt\TokenProviderInterface`
- added `Jwt\TokenFactoryInterface`
- added `Jwt\StaticTokenProvider`
- added `Jwt\CallabkeTokenProvider` 
- added `Jwt\LcobucciTokenFactory`
- added `Jwt\FactoryTokenProvider`
- added `Messenger\UpdateHandler`
- added `Hub`

### deprecations
- `Jwt\StaticJwtProvider` has been deprecated, use `Jwt\StaticTokenProvider` instead.
- `Publisher::__invoke` method has been deprecated, use `Publisher::publish` instead.
- passing a url and a callable jwt provider to `Publisher::__construct` is deprecated, pass a `Hub` instance instead.
- `PublisherInterface::__invoke` method has been deprecated in favor of `PublisherInterface::publish`.
