### PR TITLE
Remove deprecated `__invoke()` from PublisherInterface

### DIFF
--- a/src/Debug/TraceablePublisher.php
+++ b/src/Debug/TraceablePublisher.php
@@ -37,6 +37,9 @@ final class TraceablePublisher implements PublisherInterface, ResetInterface
         $this->stopwatch = $stopwatch;
     }
 
+    /**
+     * @deprecated since symfony/mercure 0.5
+     */
     public function __invoke(Update $update): string
     {
         trigger_deprecation('symfony/mercure', '0.5', 'Method "%s()" is deprecated, use "%s::publish()" instead.', __METHOD__, __CLASS__);
@@ -51,6 +54,7 @@ final class TraceablePublisher implements PublisherInterface, ResetInterface
         if (method_exists($this->publisher, 'publish')) {
             $content = $this->publisher->publish($update);
         } else {
+            trigger_deprecation('symfony/mercure', '0.5', 'Method "%1$s()" is deprecated, implement "%1$s::publish()" instead.', PublisherInterface::class);
             $content = ($this->publisher)($update);
         }
 

--- a/src/MockPublisher.php
+++ b/src/MockPublisher.php
@@ -29,14 +29,4 @@ final class MockPublisher implements PublisherInterface
     {
         return ($this->callable)($update);
     }
-
-    /**
-     * @deprecated since 0.5, use {@see PublisherInterface::publish} instead.
-     */
-    public function __invoke(Update $update): string
-    {
-        trigger_deprecation('symfony/mercure', '0.5', 'Method "%s()" is deprecated, use "%s::publish()" instead.', __METHOD__, __CLASS__);
-
-        return ($this->callable)($update);
-    }
 }

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -47,6 +47,9 @@ final class Publisher implements PublisherInterface
         $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
+    /**
+     * @deprecated since symfony/mercure 0.5
+     */
     public function __invoke(Update $update): string
     {
         trigger_deprecation('symfony/mercure', '0.5', 'Method "%s()" is deprecated, use "%s::publish()" instead.', __METHOD__, __CLASS__);
@@ -55,7 +58,7 @@ final class Publisher implements PublisherInterface
     }
 
     /**
-     * Sends $update to the mercure hub.
+     * {@inheritdoc}
      */
     public function publish(Update $update): string
     {

--- a/src/PublisherInterface.php
+++ b/src/PublisherInterface.php
@@ -18,12 +18,8 @@ namespace Symfony\Component\Mercure;
  *
  * @experimental
  *
- * @method string publish(Update $update)
+ * @method string publish(Update $update) Sends $update to the mercure hub.
  */
 interface PublisherInterface
 {
-    /**
-     * @deprecated since 0.5, use {@see PublisherInterface::publish} instead.
-     */
-    public function __invoke(Update $update): string;
 }


### PR DESCRIPTION
Removing the deprecated method is how we deal with such cases in Symfony core as it's the best tradeoff we could think of so far:
New projects should not be forced to implement the deprecated method, nor getting deprecation notices that they cannot fix. That's what keeping the deprecated method implies. 
By removing the method, current projects implementing it will get deprecations notices from callers in this library.
/cc @azjezz 