### PR TITLE
Fixed typo in readme, where Publisher is used together with Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ define('HUB_URL', 'https://demo.mercure.rocks/.well-known/mercure');
 define('JWT', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM');
 
 use Symfony\Component\Mercure\Hub;
-use Symfony\Component\Mercure\Publisher;
 use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Update;
 
 $hub = new Hub(HUB_URL, new StaticTokenProvider(JWT));
-$publisher = new Publisher($hub);
 // Serialize the update, and dispatch it to the hub, that will broadcast it to the clients
-$id = $publisher->publish(new Update('https://example.com/books/1.jsonld', 'Hi from Symfony!'));
+$id = $hub->publish(new Update('https://example.com/books/1.jsonld', 'Hi from Symfony!'));
 ```
 
 Resources


### PR DESCRIPTION
This fixes a typo in the README file, where the new `Hub` and the deprecated `Publisher` classes are used together, even injecting the former in the latter, which does not fulfill its actual signature.