### PR TITLE
Allow to set a default expiration value on the generated token

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-${{ matrix.operating-system }}"
 
       - name: "removing 'lcobucci/jwt' dependency"
-        if: "${{ matrix.php != '7.4' }} && ${{ matrix.php != '8.0' }}"
+        if: "${{ matrix.php-version != '7.4' }} && ${{ matrix.php-version != '8.0' }}"
         run: "composer remove --no-update --dev lcobucci/jwt"
 
       - name: "installing lowest dependencies"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-${{ matrix.operating-system }}"
 
       - name: "removing 'lcobucci/jwt' dependency"
-        if: "${{ matrix.php-version != '7.4' }} && ${{ matrix.php-version != '8.0' }}"
+        if: ${{ matrix.php-version != '7.4' && matrix.php-version != '8.0' }}
         run: "composer remove --no-update --dev lcobucci/jwt"
 
       - name: "installing lowest dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.5.2
+-----
+
+* Set a defaut expiration for the JWT and the cookie when using the `Authorization` class
+
 0.5.1
 -----
 

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -41,7 +41,6 @@ final class Authorization
      * @param string[]    $publish          a list of topics that the authorization cookie will allow publishing to
      * @param mixed[]     $additionalClaims an array of additional claims for the JWT
      * @param string|null $hub              the hub to generate the cookie for
-     * @param int|null    $cookieLifetime   the lifetime of the cookie, the "exp" claim of the JWT will be set accordingly, set to null to use the default value and to 0 to set a session cookie (the default expiration time of the JWT will be 1 hour)
      */
     public function createCookie(Request $request, array $subscribe = [], array $publish = [], array $additionalClaims = [], ?string $hub = null): Cookie
     {

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -23,15 +23,15 @@ final class Authorization
     private const MERCURE_AUTHORIZATION_COOKIE_NAME = 'mercureAuthorization';
 
     private $registry;
-    private $defaultLifetime;
+    private $cookieLifetime;
 
     /**
-     * @param int|null $defaultLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds) and the cookie will expire at the same time
+     * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the vlaue of "session.cookie_lifetime". The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
      */
-    public function __construct(HubRegistry $registry, ?int $defaultLifetime = 3600)
+    public function __construct(HubRegistry $registry, ?int $cookieLifetime = null)
     {
         $this->registry = $registry;
-        $this->defaultLifetime = $defaultLifetime;
+        $this->cookieLifetime = $cookieLifetime ?? (int) ini_get('session.cookie_lifetime');
     }
 
     /**
@@ -41,8 +41,9 @@ final class Authorization
      * @param string[]    $publish          a list of topics that the authorization cookie will allow publishing to
      * @param mixed[]     $additionalClaims an array of additional claims for the JWT
      * @param string|null $hub              the hub to generate the cookie for
+     * @param int|null    $cookieLifetime   the lifetime of the cookie, the "exp" claim of the JWT will be set accordingly, set to null to use the default value and to 0 to set a session cookie (the default expiration time of the JWT will be 1 hour)
      */
-    public function createCookie(Request $request, array $subscribe = [], array $publish = [], array $additionalClaims = [], ?string $hub = null): Cookie
+    public function createCookie(Request $request, array $subscribe = [], array $publish = [], array $additionalClaims = [], ?string $hub = null, ?int $cookieLifetime = null): Cookie
     {
         $hubInstance = $this->registry->getHub($hub);
         $tokenFactory = $hubInstance->getFactory();
@@ -50,8 +51,13 @@ final class Authorization
             throw new InvalidArgumentException(sprintf('The %s hub does not contain a token factory.', $hub ? '"'.$hub.'"' : 'default'));
         }
 
-        if (null !== $this->defaultLifetime && !isset($additionalClaims['exp'])) {
-            $additionalClaims['exp'] = new \DateTimeImmutable("+{$this->defaultLifetime} seconds");
+        if (array_key_exists('exp', $additionalClaims)) {
+            if (null !== $additionalClaims['exp'] && null === $cookieLifetime) {
+                $cookieLifetime = $additionalClaims['exp'];
+            }
+        } else {
+            $cookieLifetime = $cookieLifetime ?? $this->cookieLifetime;
+            $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
         }
 
         $token = $tokenFactory->create($subscribe, $publish, $additionalClaims);
@@ -59,33 +65,38 @@ final class Authorization
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);
 
-        $cookie = Cookie::create(self::MERCURE_AUTHORIZATION_COOKIE_NAME)
-            ->withValue($token)
-            ->withPath(($urlComponents['path'] ?? '/'))
-            ->withSecure('http' !== strtolower($urlComponents['scheme'] ?? 'https'))
-            ->withHttpOnly(true)
-            ->withSameSite(Cookie::SAMESITE_STRICT)
-           ;
 
-        if (isset($additionalClaims['exp'])) {
-            $cookie->withExpires($additionalClaims['exp']);
+
+        return Cookie::create(
+            self::MERCURE_AUTHORIZATION_COOKIE_NAME,
+            $token,
+            $cookieLifetime ?? $this->cookieLifetime,
+            $urlComponents['path'] ?? '/',
+            $this->getCookieDomain($request, $urlComponents),
+            'http' !== strtolower($urlComponents['scheme'] ?? 'https'),
+            true,
+            false,
+            Cookie::SAMESITE_STRICT
+        );
+    }
+
+    private function getCookieDomain(Request $request, array $urlComponents): ?string
+    {
+        if (!isset($urlComponents['host'])) {
+            return null;
         }
 
-        if (isset($urlComponents['host'])) {
-            $cookieDomain = strtolower($urlComponents['host']);
-            $currentDomain = strtolower($request->getHost());
+        $cookieDomain = strtolower($urlComponents['host']);
+        $currentDomain = strtolower($request->getHost());
 
-            if ($cookieDomain === $currentDomain) {
-                return $cookie;
-            }
-
-            if (!str_ends_with($cookieDomain, ".${currentDomain}")) {
-                throw new RuntimeException(sprintf('Unable to create authorization cookie for external domain "%s".', $cookieDomain));
-            }
-
-            $cookie = $cookie->withDomain($cookieDomain);
+        if ($cookieDomain === $currentDomain) {
+            return null;
         }
 
-        return $cookie;
+        if (!str_ends_with($cookieDomain, ".${currentDomain}")) {
+            throw new RuntimeException(sprintf('Unable to create authorization cookie for a hub on the different second-level domain "%s".', $cookieDomain));
+        }
+
+        return $cookieDomain;
     }
 }

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -65,10 +65,17 @@ final class Authorization
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);
 
+        if (null === $cookieLifetime) {
+            $cookieLifetime = $this->cookieLifetime;
+        }
+        if (!$cookieLifetime instanceof \DateTimeInterface && 0 !== $cookieLifetime) {
+            $cookieLifetime = new \DateTimeImmutable("+{$cookieLifetime} seconds");
+        }
+
         return Cookie::create(
             self::MERCURE_AUTHORIZATION_COOKIE_NAME,
             $token,
-            $cookieLifetime ?? $this->cookieLifetime,
+            $cookieLifetime,
             $urlComponents['path'] ?? '/',
             $this->getCookieDomain($request, $urlComponents),
             'http' !== strtolower($urlComponents['scheme'] ?? 'https'),

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -48,10 +48,10 @@ final class Authorization
         $hubInstance = $this->registry->getHub($hub);
         $tokenFactory = $hubInstance->getFactory();
         if (null === $tokenFactory) {
-            throw new InvalidArgumentException(sprintf('The %s hub does not contain a token factory.', $hub ? '"'.$hub.'"' : 'default'));
+            throw new InvalidArgumentException(sprintf('The "%s" hub does not contain a token factory.', $hub ? '"'.$hub.'"' : 'default'));
         }
 
-        if (array_key_exists('exp', $additionalClaims)) {
+        if (\array_key_exists('exp', $additionalClaims)) {
             if (null !== $additionalClaims['exp'] && null === $cookieLifetime) {
                 $cookieLifetime = $additionalClaims['exp'];
             }
@@ -64,8 +64,6 @@ final class Authorization
         $url = $hubInstance->getPublicUrl();
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);
-
-
 
         return Cookie::create(
             self::MERCURE_AUTHORIZATION_COOKIE_NAME,

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -26,7 +26,7 @@ final class Authorization
     private $cookieLifetime;
 
     /**
-     * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the vlaue of "session.cookie_lifetime". The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
+     * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the value of "session.cookie_lifetime". The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
      */
     public function __construct(HubRegistry $registry, ?int $cookieLifetime = null)
     {

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -26,7 +26,7 @@ final class Authorization
     private $cookieLifetime;
 
     /**
-     * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the value of "session.cookie_lifetime". The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
+     * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the value of "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0. The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
      */
     public function __construct(HubRegistry $registry, ?int $cookieLifetime = null)
     {

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -43,7 +43,7 @@ final class Authorization
      * @param string|null $hub              the hub to generate the cookie for
      * @param int|null    $cookieLifetime   the lifetime of the cookie, the "exp" claim of the JWT will be set accordingly, set to null to use the default value and to 0 to set a session cookie (the default expiration time of the JWT will be 1 hour)
      */
-    public function createCookie(Request $request, array $subscribe = [], array $publish = [], array $additionalClaims = [], ?string $hub = null, ?int $cookieLifetime = null): Cookie
+    public function createCookie(Request $request, array $subscribe = [], array $publish = [], array $additionalClaims = [], ?string $hub = null): Cookie
     {
         $hubInstance = $this->registry->getHub($hub);
         $tokenFactory = $hubInstance->getFactory();
@@ -51,12 +51,12 @@ final class Authorization
             throw new InvalidArgumentException(sprintf('The "%s" hub does not contain a token factory.', $hub ? '"'.$hub.'"' : 'default'));
         }
 
+        $cookieLifetime = $this->cookieLifetime;
         if (\array_key_exists('exp', $additionalClaims)) {
-            if (null !== $additionalClaims['exp'] && null === $cookieLifetime) {
+            if (null !== $additionalClaims['exp']) {
                 $cookieLifetime = $additionalClaims['exp'];
             }
         } else {
-            $cookieLifetime = $cookieLifetime ?? $this->cookieLifetime;
             $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
         }
 
@@ -65,9 +65,6 @@ final class Authorization
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);
 
-        if (null === $cookieLifetime) {
-            $cookieLifetime = $this->cookieLifetime;
-        }
         if (!$cookieLifetime instanceof \DateTimeInterface && 0 !== $cookieLifetime) {
             $cookieLifetime = new \DateTimeImmutable("+{$cookieLifetime} seconds");
         }

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -23,15 +23,10 @@ final class Authorization
     private const MERCURE_AUTHORIZATION_COOKIE_NAME = 'mercureAuthorization';
 
     private $registry;
-    private $jwtLifetime;
 
-    /**
-     * @param int|null $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds)
-     */
-    public function __construct(HubRegistry $registry, int $jwtLifetime = null)
+    public function __construct(HubRegistry $registry)
     {
         $this->registry = $registry;
-        $this->jwtLifetime = $jwtLifetime;
     }
 
     /**
@@ -48,10 +43,6 @@ final class Authorization
         $tokenFactory = $hubInstance->getFactory();
         if (null === $tokenFactory) {
             throw new InvalidArgumentException(sprintf('The %s hub does not contain a token factory.', $hub ? '"'.$hub.'"' : 'default'));
-        }
-
-        if (null !== $this->jwtLifetime && !isset($additionalClaims['exp'])) {
-            $additionalClaims['exp'] = new \DateTimeImmutable("+{$this->jwtLifetime} seconds");
         }
 
         $token = $tokenFactory->create($subscribe, $publish, $additionalClaims);

--- a/src/HubRegistry.php
+++ b/src/HubRegistry.php
@@ -23,7 +23,7 @@ final class HubRegistry
     /**
      * @param array<string, HubInterface> $hubs An array of hub instances, where the keys are the names
      */
-    public function __construct(HubInterface $defaultHub, array $hubs)
+    public function __construct(HubInterface $defaultHub, array $hubs = [])
     {
         $this->defaultHub = $defaultHub;
         $this->hubs = $hubs;

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -67,7 +67,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     {
         $builder = $this->configurations->builder();
 
-        if (null !== $this->jwtLifetime && !array_key_exists('exp', $additionalClaims)) {
+        if (null !== $this->jwtLifetime && !\array_key_exists('exp', $additionalClaims)) {
             $additionalClaims['exp'] = new \DateTimeImmutable("+{$this->jwtLifetime} seconds");
         }
 

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -42,7 +42,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     /**
      * @param int|null $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds), defaults to "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0.
      */
-    public function __construct(string $secret, string $algorithm = 'hmac.sha256', ?int $jwtLifetime = null)
+    public function __construct(string $secret, string $algorithm = 'hmac.sha256', ?int $jwtLifetime = 0)
     {
         if (!class_exists(Key\InMemory::class)) {
             throw new \LogicException('You cannot use "Symfony\Component\Mercure\Token\LcobucciFactory" as the "lcobucci/jwt" package is not installed. Try running "composer require lcobucci/jwt".');
@@ -57,7 +57,7 @@ final class LcobucciFactory implements TokenFactoryInterface
             new $signerClass(),
             Key\InMemory::plainText($secret)
         );
-        $this->jwtLifetime = $jwtLifetime ?? ((int) ini_get('session.cookie_lifetime') ?: 3600);
+        $this->jwtLifetime = 0 === $jwtLifetime ? ((int) ini_get('session.cookie_lifetime') ?: 3600) : $jwtLifetime;
     }
 
     /**

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -40,9 +40,9 @@ final class LcobucciFactory implements TokenFactoryInterface
     private $jwtLifetime;
 
     /**
-     * @param int|null $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds)
+     * @param int|null $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds), defaults to "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0.
      */
-    public function __construct(string $secret, string $algorithm = 'hmac.sha256', ?int $jwtLifetime = 3600)
+    public function __construct(string $secret, string $algorithm = 'hmac.sha256', ?int $jwtLifetime = null)
     {
         if (!class_exists(Key\InMemory::class)) {
             throw new \LogicException('You cannot use "Symfony\Component\Mercure\Token\LcobucciFactory" as the "lcobucci/jwt" package is not installed. Try running "composer require lcobucci/jwt".');
@@ -57,7 +57,7 @@ final class LcobucciFactory implements TokenFactoryInterface
             new $signerClass(),
             Key\InMemory::plainText($secret)
         );
-        $this->jwtLifetime = $jwtLifetime;
+        $this->jwtLifetime = $jwtLifetime ?? ((int) ini_get('session.cookie_lifetime') ?: 3600);
     }
 
     /**

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -67,7 +67,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     {
         $builder = $this->configurations->builder();
 
-        if (null !== $this->jwtLifetime && !isset($additionalClaims['exp'])) {
+        if (null !== $this->jwtLifetime && !array_key_exists('exp', $additionalClaims)) {
             $additionalClaims['exp'] = new \DateTimeImmutable("+{$this->jwtLifetime} seconds");
         }
 
@@ -82,7 +82,9 @@ final class LcobucciFactory implements TokenFactoryInterface
                     $builder = $builder->permittedFor(...(array) $value);
                     break;
                 case RegisteredClaims::EXPIRATION_TIME:
-                    $builder = $builder->expiresAt($value);
+                    if (null !== $value) {
+                        $builder = $builder->expiresAt($value);
+                    }
                     break;
                 case RegisteredClaims::ISSUED_AT:
                     $builder = $builder->issuedAt($value);

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -37,6 +37,7 @@ final class Publisher implements PublisherInterface
 
     /**
      * @param TokenProviderInterface|callable(Update $update):string $jwtProvider
+     * @param mixed                                  $jwtProvider
      */
     public function __construct(string $hubUrl, $jwtProvider, HttpClientInterface $httpClient = null)
     {

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -37,7 +37,6 @@ final class Publisher implements PublisherInterface
 
     /**
      * @param TokenProviderInterface|callable(Update $update):string $jwtProvider
-     * @param mixed                                  $jwtProvider
      */
     public function __construct(string $hubUrl, $jwtProvider, HttpClientInterface $httpClient = null)
     {

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -33,10 +33,10 @@ class AuthorizationTest extends TestCase
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
-            new LcobucciFactory('secret')
-        ), []);
+            new LcobucciFactory('secret', 'hmac.sha256', 3600)
+        ));
 
-        $authorization = new Authorization($registry, 3600);
+        $authorization = new Authorization($registry);
         $cookie = $authorization->createCookie(Request::create('https://example.com'));
 
         $payload = json_decode(base64_decode(explode('.', $cookie->getValue())[1], true), true);

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Mercure\Tests;
 
+use Lcobucci\JWT\Signer\Key\InMemory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\Authorization;
@@ -27,11 +28,12 @@ use Symfony\Component\Mercure\Update;
  */
 class AuthorizationTest extends TestCase
 {
-    /**
-     * @requires PHP 7.4
-     */
     public function testJwtLifetime(): void
     {
+        if (!class_exists(InMemory::class)) {
+            $this->markTestSkipped('"lcobucci/jwt" is not installed');
+        }
+
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mercure\Authorization;
+use Symfony\Component\Mercure\HubRegistry;
+use Symfony\Component\Mercure\Jwt\LcobucciFactory;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
+use Symfony\Component\Mercure\MockHub;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * @author Kévin Dunglas <kevin@dunglas.fr>
+ */
+class AuthorizationTest extends TestCase
+{
+    public function testJwtLifetime(): void
+    {
+        $registry = new HubRegistry(new MockHub(
+            'https://example.com/.well-known/mercure',
+            new StaticTokenProvider('foo.bar.baz'),
+            function (Update $u): string { return 'dummy'; },
+            new LcobucciFactory('secret')
+        ), []);
+
+        $authorization = new Authorization($registry, 3600);
+        $cookie = $authorization->createCookie(Request::create('https://example.com'));
+
+        $payload = json_decode(base64_decode(explode('.', $cookie->getValue())[1], true), true);
+        $this->assertArrayHasKey('exp', $payload);
+        $this->assertIsFloat($payload['exp']);
+    }
+}

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -27,6 +27,9 @@ use Symfony\Component\Mercure\Update;
  */
 class AuthorizationTest extends TestCase
 {
+    /**
+     * @requires PHP 7.4
+     */
     public function testJwtLifetime(): void
     {
         $registry = new HubRegistry(new MockHub(

--- a/tests/Jwt/FactoryTokenProviderTest.php
+++ b/tests/Jwt/FactoryTokenProviderTest.php
@@ -26,7 +26,7 @@ final class FactoryTokenProviderTest extends TestCase
             $this->markTestSkipped('requires lcobucci/jwt:^4.0.');
         }
 
-        $factory = new LcobucciFactory('!ChangeMe!','hmac.sha256', null);
+        $factory = new LcobucciFactory('!ChangeMe!', 'hmac.sha256', null);
         $provider = new FactoryTokenProvider($factory, [], ['*']);
 
         $this->assertSame(

--- a/tests/Jwt/FactoryTokenProviderTest.php
+++ b/tests/Jwt/FactoryTokenProviderTest.php
@@ -26,7 +26,7 @@ final class FactoryTokenProviderTest extends TestCase
             $this->markTestSkipped('requires lcobucci/jwt:^4.0.');
         }
 
-        $factory = new LcobucciFactory('!ChangeMe!');
+        $factory = new LcobucciFactory('!ChangeMe!','hmac.sha256', null);
         $provider = new FactoryTokenProvider($factory, [], ['*']);
 
         $this->assertSame(

--- a/tests/Jwt/LcobucciFactoryTest.php
+++ b/tests/Jwt/LcobucciFactoryTest.php
@@ -29,7 +29,7 @@ final class LcobucciFactoryTest extends TestCase
 
     public function testCreate(): void
     {
-        $factory = new LcobucciFactory('!ChangeMe!');
+        $factory = new LcobucciFactory('!ChangeMe!','hmac.sha256', null);
 
         $this->assertSame(
             'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',

--- a/tests/Jwt/LcobucciFactoryTest.php
+++ b/tests/Jwt/LcobucciFactoryTest.php
@@ -29,7 +29,7 @@ final class LcobucciFactoryTest extends TestCase
 
     public function testCreate(): void
     {
-        $factory = new LcobucciFactory('!ChangeMe!','hmac.sha256', null);
+        $factory = new LcobucciFactory('!ChangeMe!', 'hmac.sha256', null);
 
         $this->assertSame(
             'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',


### PR DESCRIPTION
Generating JWT without expiration is a bad security practice. This PR adds the ability to set a default lifetime for generated tokens using the new `Authorization` util. 