### PR TITLE
Add lastEventId option to Twig extension

### DIFF
--- a/src/Twig/MercureExtension.php
+++ b/src/Twig/MercureExtension.php
@@ -43,8 +43,8 @@ final class MercureExtension extends AbstractExtension
     }
 
     /**
-     * @param string|string[]|null                                                                                   $topics  A topic or an array of topics to subscribe for. If this parameter is omitted or `null` is passed, the URL of the hub will be returned (useful for publishing in JavaScript).
-     * @param array{subscribe?: string[]|string, publish?: string[]|string, additionalClaims?: array<string, mixed>} $options The options to pass to the JWT factory
+     * @param string|string[]|null                                                                                                         $topics  A topic or an array of topics to subscribe for. If this parameter is omitted or `null` is passed, the URL of the hub will be returned (useful for publishing in JavaScript).
+     * @param array{subscribe?: string[]|string, publish?: string[]|string, additionalClaims?: array<string, mixed>, lastEventId?: string} $options The options to pass to the JWT factory
      *
      * @return string The URL of the hub with the appropriate "topic" query parameters (if any)
      */
@@ -61,6 +61,10 @@ final class MercureExtension extends AbstractExtension
                     $separator = '&';
                 }
             }
+        }
+
+        if ('' !== $options['lastEventId'] ?? '') {
+            $url .= '&Last-Event-ID='.rawurlencode($options['lastEventId']);
         }
 
         if (

--- a/src/Twig/MercureExtension.php
+++ b/src/Twig/MercureExtension.php
@@ -63,7 +63,7 @@ final class MercureExtension extends AbstractExtension
             }
         }
 
-        if ('' !== $options['lastEventId'] ?? '') {
+        if ('' !== ($options['lastEventId'] ?? '')) {
             $url .= '&Last-Event-ID='.rawurlencode($options['lastEventId']);
         }
 

--- a/tests/Twig/MercureExtensionTest.php
+++ b/tests/Twig/MercureExtensionTest.php
@@ -50,4 +50,28 @@ class MercureExtensionTest extends TestCase
         $this->assertSame('https://example.com/.well-known/mercure?topic=https%3A%2F%2Ffoo%2Fbar', $url);
         $this->assertInstanceOf(Cookie::class, $request->attributes->get('_mercure_authorization_cookies')['']);
     }
+
+    public function testMercureLastEventId(): void
+    {
+        $registry = new HubRegistry(new MockHub(
+            'https://example.com/.well-known/mercure',
+            new StaticTokenProvider('foo.bar.baz'),
+            function (Update $u): string {
+                return 'dummy';
+            },
+            $this->createMock(TokenFactoryInterface::class)
+        ));
+
+        $requestStack = new RequestStack();
+        $request = Request::create('https://example.com/');
+        $requestStack->push($request);
+
+        $extension = new MercureExtension($registry, new Authorization($registry), $requestStack);
+
+        $url = $extension->mercure(['https://foo/bar'], [
+            'lastEventId' => 'urn:uuid:13697bc5-e3c6-48cf-99c8-9d64c26f1a2f',
+        ]);
+
+        $this->assertSame('https://example.com/.well-known/mercure?topic=https%3A%2F%2Ffoo%2Fbar&Last-Event-ID=urn%3Auuid%3A13697bc5-e3c6-48cf-99c8-9d64c26f1a2f', $url);
+    }
 }


### PR DESCRIPTION
Allow the option `lastEventId` to be passed into the `mercure()` Twig extension options, which then sets `Last-Event-ID` into the subscriber url.