### PR TITLE
fix: Set Content-Type header always to application/x-www-form-urlencoded

### DIFF
--- a/src/Hub.php
+++ b/src/Hub.php
@@ -98,6 +98,9 @@ final class Hub implements HubInterface
         try {
             return $this->httpClient->request('POST', $this->getUrl(), [
                 'auth_bearer' => $jwt,
+                'headers' => [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                ],
                 'body' => Internal\QueryBuilder::build($postData),
             ])->getContent();
         } catch (ExceptionInterface $exception) {

--- a/tests/HubTest.php
+++ b/tests/HubTest.php
@@ -40,9 +40,16 @@ class HubTest extends TestCase
             $this->assertSame(self::URL, $url);
             $this->assertSame(self::AUTH_HEADER, $options['normalized_headers']['authorization'][0]);
             $this->assertSame('topic=https%3A%2F%2Fdemo.mercure.rocks%2Fdemo%2Fbooks%2F1.jsonld&data=Hi+from+Symfony%21&private=on&id=id&retry=3', $options['body']);
+            $this->assertSame('Content-Type: application/x-www-form-urlencoded', $options['normalized_headers']['content-type'][0]);
 
             return new MockResponse('id');
         });
+
+        $httpClient = $httpClient->withOptions([
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ]);
 
         $provider = new StaticTokenProvider(self::JWT);
         $hub = new Hub(self::URL, $provider, null, null, $httpClient);


### PR DESCRIPTION
This ensures the Content-Type, even if the used HttpClient has default settings like `Content-Type: application/json`, mercure understand the request and does not response with `Missing "topic" parameter`.