### PR TITLE
Patch for setting the lifetime of the cookie

### DIFF
--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -79,12 +79,11 @@ final class Authorization
 
         $cookieLifetime = $this->cookieLifetime;
         if (\array_key_exists('exp', $additionalClaims)) {
-            if (null !== $additionalClaims['exp']) {
+            if (null !== $additionalClaims['exp'] && is_int($additionalClaims['exp'])) {
                 $cookieLifetime = $additionalClaims['exp'];
             }
-        } else {
-            $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
         }
+        $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
 
         $token = $tokenFactory->create((array) $subscribe, (array) $publish, $additionalClaims);
         $url = $hubInstance->getPublicUrl();

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -79,7 +79,7 @@ final class Authorization
 
         $cookieLifetime = $this->cookieLifetime;
         if (\array_key_exists('exp', $additionalClaims)) {
-            if (null !== $additionalClaims['exp'] && is_int($additionalClaims['exp'])) {
+            if (null !== $additionalClaims['exp'] && \is_int($additionalClaims['exp'])) {
                 $cookieLifetime = $additionalClaims['exp'];
             }
         }

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -90,7 +90,7 @@ final class Authorization
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);
 
-        if (!$cookieLifetime instanceof \DateTimeInterface && 0 !== $cookieLifetime) {
+        if (0 !== $cookieLifetime) {
             $cookieLifetime = new \DateTimeImmutable("+{$cookieLifetime} seconds");
         }
 

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -73,7 +73,7 @@ class AuthorizationTest extends TestCase
 
         $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
         $this->assertNotNull($cookie->getValue());
-        $this->assertSame(3600, $cookie->getExpiresTime());
+        $this->assertNotSame(0, $cookie->getExpiresTime());
     }
 
     public function testClearCookie(): void

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -69,11 +69,11 @@ class AuthorizationTest extends TestCase
 
         $request = Request::create('https://example.com');
         $authorization = new Authorization($registry, 0);
-        $authorization->setCookie($request, ['foo'], ['bar'], ['x-foo' => 'bar']);
+        $authorization->setCookie($request, ['foo'], ['bar'], ['x-foo' => 'bar', 'exp' => 3600]);
 
         $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
         $this->assertNotNull($cookie->getValue());
-        $this->assertSame(0, $cookie->getExpiresTime());
+        $this->assertSame(3600, $cookie->getExpiresTime());
     }
 
     public function testClearCookie(): void


### PR DESCRIPTION
I'm working on auto-generating private topics read permission.

My subscriber use :
```php
$this->discovery->addLink($request);
$this->authorization->setCookie(
        request: $request,
        subscribe: ['https://' . $_ENV['SERVER_NAME'] . User::USER_URI . '/' . $user->getId()],
        additionalClaims: ['exp' => new \DateTimeImmutable("+86400 seconds")]
);
```

Method setCookie use LcobucciFactory->create(...) and Builder->expiresAt(DateTimeImmutable $expiration).

I use Authorization->setCookie(...) and i want set expiration cookie with additionalClaims: ['exp' => 86400] and not with additionalClaims: ['exp' => new \DateTimeImmutable("+86400 seconds")].
An exception is thrown if a DateTimeImmutable is not used.