### PR TITLE
add fast publishing method

### DIFF
--- a/src/HubInterface.php
+++ b/src/HubInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Mercure;
 
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Saif Eddin Gmati <azjezz@protonmail.com>
@@ -50,4 +51,15 @@ interface HubInterface
      * Publish an update to this Hub.
      */
     public function publish(Update $update): string;
+
+    /**
+     * Publish an update to this Hub.
+     *
+     */
+    public function publishFast(Update $update, ?string $token = null): ResponseInterface;
+    /**
+     * Publish updates to this Hub.
+     * @param Iterable<Update> $updates
+     */
+    public function publishBatch($updates, bool $fireAndForget = false): array;
 }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Mercure\Tests;
 
 use Lcobucci\JWT\Signer\Key\InMemory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\Authorization;
 use Symfony\Component\Mercure\Exception\RuntimeException;
@@ -24,6 +25,7 @@ use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\MockHub;
 use Symfony\Component\Mercure\Update;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Kévin Dunglas <kevin@dunglas.fr>
@@ -39,7 +41,9 @@ class AuthorizationTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
             new LcobucciFactory('secret', 'hmac.sha256', 3600)
         ));
 
@@ -57,13 +61,14 @@ class AuthorizationTest extends TestCase
         $tokenFactory
             ->expects($this->once())
             ->method('create')
-            ->with($this->equalTo(['foo']), $this->equalTo(['bar']), $this->arrayHasKey('x-foo'))
-        ;
+            ->with($this->equalTo(['foo']), $this->equalTo(['bar']), $this->arrayHasKey('x-foo'));
 
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
             $tokenFactory
         ));
 
@@ -81,8 +86,11 @@ class AuthorizationTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
-            new class() implements TokenFactoryInterface {
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
+            new class() implements TokenFactoryInterface
+            {
                 public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string
                 {
                     return '';
@@ -111,7 +119,9 @@ class AuthorizationTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             $hubUrl,
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
             new LcobucciFactory('secret', 'hmac.sha256', 3600)
         ));
 
@@ -143,7 +153,9 @@ class AuthorizationTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             $hubUrl,
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
             new LcobucciFactory('secret', 'hmac.sha256', 3600)
         ));
 
@@ -168,8 +180,11 @@ class AuthorizationTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
-            new class() implements TokenFactoryInterface {
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
+            new class() implements TokenFactoryInterface
+            {
                 public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string
                 {
                     return '';

--- a/tests/HubRegistryTest.php
+++ b/tests/HubRegistryTest.php
@@ -18,13 +18,19 @@ use Symfony\Component\Mercure\Exception\InvalidArgumentException;
 use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\MockHub;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class HubRegistryTest extends TestCase
 {
     public function testGetHubByName(): void
     {
-        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): string { return 'foo'; });
-        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): string { return 'bar'; });
+        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): ResponseInterface {
+            return new MockResponse('foo');
+        });
+        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): ResponseInterface {
+            return new MockResponse('bar');
+        });
         $registry = new HubRegistry($fooHub, ['foo' => $fooHub, 'bar' => $barHub]);
 
         $this->assertSame($fooHub, $registry->getHub('foo'));
@@ -32,8 +38,12 @@ class HubRegistryTest extends TestCase
 
     public function testGetDefaultHub(): void
     {
-        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): string { return 'foo'; });
-        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): string { return 'bar'; });
+        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): ResponseInterface {
+            return new MockResponse('foo');
+        });
+        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): ResponseInterface {
+            return new MockResponse('bar');
+        });
         $registry = new HubRegistry($fooHub, ['foo' => $fooHub, 'bar' => $barHub]);
 
         $this->assertSame($fooHub, $registry->getHub());
@@ -41,7 +51,9 @@ class HubRegistryTest extends TestCase
 
     public function testGetMissingHubThrows(): void
     {
-        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): string { return 'foo'; });
+        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): ResponseInterface {
+            return new MockResponse('foo');
+        });
         $registry = new HubRegistry($fooHub, ['foo' => $fooHub]);
 
         $this->expectException(InvalidArgumentException::class);
@@ -50,8 +62,12 @@ class HubRegistryTest extends TestCase
 
     public function testGetAllHubs(): void
     {
-        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): string { return 'foo'; });
-        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): string { return 'bar'; });
+        $fooHub = new MockHub('fooUrl', new StaticTokenProvider('fooToken'), static function (): ResponseInterface {
+            return new MockResponse('foo');
+        });
+        $barHub = new MockHub('barUrl', new StaticTokenProvider('barToken'), static function (): ResponseInterface {
+            return new MockResponse('bar');
+        });
         $registry = new HubRegistry($fooHub, ['foo' => $fooHub, 'bar' => $barHub]);
 
         $this->assertSame(['foo' => $fooHub, 'bar' => $barHub], $registry->all());

--- a/tests/Twig/MercureExtensionTest.php
+++ b/tests/Twig/MercureExtensionTest.php
@@ -22,7 +22,9 @@ use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\MockHub;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mercure\Twig\MercureExtension;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Component\Mercure\Update;
 
 /**
@@ -35,7 +37,9 @@ class MercureExtensionTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string { return 'dummy'; },
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
+            },
             $this->createMock(TokenFactoryInterface::class)
         ));
 
@@ -56,8 +60,8 @@ class MercureExtensionTest extends TestCase
         $registry = new HubRegistry(new MockHub(
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
-            function (Update $u): string {
-                return 'dummy';
+            function (Update $u): ResponseInterface {
+                return new MockResponse('dummy');
             },
             $this->createMock(TokenFactoryInterface::class)
         ));


### PR DESCRIPTION
# what
sometimes more than update should be fired.
This MR improves the speed of updates by simultaneous executing them (see http client) (no speed comparisation done yet).
It also adds a publishFast method for fire and forget or request collect operations (publishBatch).

# Extend tested
I only used the unittests. Real life tests are still missing, as well as a speed benchmark

