### PR TITLE
Add event on Update publish to Hub

### DIFF
--- a/src/Event/UpdatePublished.php
+++ b/src/Event/UpdatePublished.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mercure\Event;
+
+use Symfony\Component\Mercure\Update;
+
+final class UpdatePublished
+{
+    private $topics;
+    private $data;
+    private $private;
+    private $id;
+    private $type;
+    private $retry;
+
+    /**
+     * @param string|string[] $topics
+     */
+    private function __construct(
+        $topics,
+        string $data = '',
+        bool $private = false,
+        string $id = null,
+        string $type = null,
+        int $retry = null
+    ) {
+        $this->topics = (array) $topics;
+        $this->data = $data;
+        $this->private = $private;
+        $this->id = $id;
+        $this->type = $type;
+        $this->retry = $retry;
+    }
+
+    public static function fromUpdate(Update $update)
+    {
+        return new self(
+            $update->getTopics(),
+            $update->getData(),
+            $update->isPrivate(),
+            $update->getId(),
+            $update->getType(),
+            $update->getRetry()
+        );
+    }
+
+    public function getTopics(): array
+    {
+        return $this->topics;
+    }
+
+    public function getData(): string
+    {
+        return $this->data;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function getRetry(): ?int
+    {
+        return $this->retry;
+    }
+}


### PR DESCRIPTION
For debugging purposes, we maintain an API log. We have a listener on `KernelEvents::TERMINATE` that writes any relevant request/response information to a log file. However we do not have this for SSE's. That's why we now decorate the `Publisher`/`Hub` to add this functionality. I thought it might be nice to submit this change as a pull request, as I can imagine it might be useful for others as well.