### PR TITLE
Return result from Messenger UpdateHandler for HandleMessageMiddleware

### DIFF
--- a/src/Messenger/UpdateHandler.php
+++ b/src/Messenger/UpdateHandler.php
@@ -34,12 +34,12 @@ final class UpdateHandler
         $this->hub = $hub;
     }
 
-    public function __invoke(Update $update): void
+    public function __invoke(Update $update)
     {
         if ($this->hub instanceof HubInterface) {
-            $this->hub->publish($update);
-        } else {
-            ($this->hub)($update);
+            return $this->hub->publish($update);
         }
+
+        return ($this->hub)($update);
     }
 }

--- a/tests/Messenger/UpdateHandlerTest.php
+++ b/tests/Messenger/UpdateHandlerTest.php
@@ -45,7 +45,7 @@ final class UpdateHandlerTest extends TestCase
         $hub = new Hub(self::URL, $provider, null, null, $httpClient);
         $handler = new UpdateHandler($hub);
 
-        $handler(new Update(
+        $result = $handler(new Update(
             'https://demo.mercure.rocks/demo/books/1.jsonld',
             'Hi from Symfony!',
             true,
@@ -53,6 +53,8 @@ final class UpdateHandlerTest extends TestCase
             null,
             3
         ));
+
+        $this->assertSame('id', $result);
     }
 
     /**
@@ -72,7 +74,7 @@ final class UpdateHandlerTest extends TestCase
         $publisher = new Publisher(self::URL, new StaticJwtProvider(self::JWT), $httpClient);
         $handler = new UpdateHandler($publisher);
 
-        $handler(new Update(
+        $result = $handler(new Update(
             'https://demo.mercure.rocks/demo/books/1.jsonld',
             'Hi from Symfony!',
             true,
@@ -80,5 +82,7 @@ final class UpdateHandlerTest extends TestCase
             null,
             3
         ));
+
+        $this->assertSame('id', $result);
     }
 }


### PR DESCRIPTION
Hello,

I was looking for the result of the update with the [HandledStamp](https://symfony.com/doc/current/messenger/handler_results.html), but it was always empty.
Then I realized the result was not returned by the `UpdateHandler`, so the middleware could not set the result properly.

So the purpose of this PR is to let the `UpdateHandler` return the result from the Hub/Publisher to retrieve it from the `HandledStamp`.

The UpdateHandler test has also been updated to test if the publisher returns the expected result from HTTP response.