### PR TITLE
fix(test): Use long enough secrets according to lcobucci/jwt 4.2+

### DIFF
--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -40,7 +40,8 @@ final class LcobucciFactory implements TokenFactoryInterface
     private $jwtLifetime;
 
     /**
-     * @param int|null $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds), defaults to "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0.
+     * @param non-empty-string $secret
+     * @param int|null         $jwtLifetime If not null, an "exp" claim is always set to now + $jwtLifetime (in seconds), defaults to "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0.
      */
     public function __construct(string $secret, string $algorithm = 'hmac.sha256', ?int $jwtLifetime = 0, string $passphrase = '')
     {
@@ -61,7 +62,7 @@ final class LcobucciFactory implements TokenFactoryInterface
             Key\InMemory::plainText($secret, $passphrase)
         );
 
-        $this->jwtLifetime = 0 === $jwtLifetime ? ((int) ini_get('session.cookie_lifetime') ?: 3600) : $jwtLifetime;
+        $this->jwtLifetime = 0 === $jwtLifetime ? ((int) \ini_get('session.cookie_lifetime') ?: 3600) : $jwtLifetime;
     }
 
     /**

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -40,7 +40,7 @@ class AuthorizationTest extends TestCase
             'https://example.com/.well-known/mercure',
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
-            new LcobucciFactory('secret', 'hmac.sha256', 3600)
+            new LcobucciFactory('looooooooooooongenoughtestsecret', 'hmac.sha256', 3600)
         ));
 
         $authorization = new Authorization($registry);
@@ -112,7 +112,7 @@ class AuthorizationTest extends TestCase
             $hubUrl,
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
-            new LcobucciFactory('secret', 'hmac.sha256', 3600)
+            new LcobucciFactory('looooooooooooongenoughtestsecret', 'hmac.sha256', 3600)
         ));
 
         $authorization = new Authorization($registry);
@@ -144,7 +144,7 @@ class AuthorizationTest extends TestCase
             $hubUrl,
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
-            new LcobucciFactory('secret', 'hmac.sha256', 3600)
+            new LcobucciFactory('looooooooooooongenoughtestsecret', 'hmac.sha256', 3600)
         ));
 
         $authorization = new Authorization($registry);

--- a/tests/Jwt/FactoryTokenProviderTest.php
+++ b/tests/Jwt/FactoryTokenProviderTest.php
@@ -26,11 +26,11 @@ final class FactoryTokenProviderTest extends TestCase
             $this->markTestSkipped('requires lcobucci/jwt.');
         }
 
-        $factory = new LcobucciFactory('!ChangeMe!', 'hmac.sha256', null);
+        $factory = new LcobucciFactory('looooooooooooongenoughtestsecret', 'hmac.sha256', null);
         $provider = new FactoryTokenProvider($factory, [], ['*']);
 
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.ZTK3JhEKO1338LAgRMw6j0lkGRMoaZtU4EtGiAylAns',
             $provider->getJwt()
         );
     }

--- a/tests/Jwt/LcobucciFactoryTest.php
+++ b/tests/Jwt/LcobucciFactoryTest.php
@@ -67,9 +67,10 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
     /**
      * @dataProvider provideCreateCases
      */
-    public function testCreate(string $algorithm, array $subscribe, array $publish, array $additionalClaims, string $expectedJwt): void
+    public function testCreate(string $secret, string $algorithm, array $subscribe, array $publish, array $additionalClaims, string $expectedJwt): void
     {
-        $factory = new LcobucciFactory('!ChangeMe!', $algorithm, null);
+        \assert('' !== $secret);
+        $factory = new LcobucciFactory($secret, $algorithm, null);
 
         $this->assertSame(
             $expectedJwt,
@@ -79,9 +80,9 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
 
     public function testCreateWithEcdsaAlgorithm(): void
     {
-        $factory = new LcobucciFactory(self::PRIVATE_ECDSA_KEY, 'ecdsa.sha384', null);
+        $factory = new LcobucciFactory(self::PRIVATE_ECDSA_KEY, 'ecdsa.sha256', null);
 
-        $this->assertStringStartsWith('eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9', $factory->create([], ['*']));
+        $this->assertStringStartsWith('eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9', $factory->create([], ['*']));
     }
 
     public function testCreateWithEncryptedRSAAlgorithm(): void
@@ -105,30 +106,34 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
     public function provideCreateCases(): iterable
     {
         yield [
+            'secret' => 'looooooooooooongenoughtestsecret',
             'algorithm' => 'hmac.sha256',
             'subscribe' => [],
             'publish' => ['*'],
             'additionalClaims' => [],
-            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.TywAqS7IPhvLdP7cXq_U-kXWUVPKFUyYz8NyfRe0vAU',
+            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.ZTK3JhEKO1338LAgRMw6j0lkGRMoaZtU4EtGiAylAns',
         ];
 
         yield [
+            'secret' => 'looooooooooooooooooooooooooooongenoughtestsecret',
             'algorithm' => 'hmac.sha384',
             'subscribe' => [],
             'publish' => ['*'],
             'additionalClaims' => [],
-            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.ABjz1sGkZ_aOZupf4oq3E4GjfhX__GioTFsrzd7KnbgtwDx0pTOohqjgOjN6vSOe',
+            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.ERwjuquA1VXjCx_Q05zHHIVWU40maCOLsu493IKD4osTk0l0bTs9t9S8_tgM32Ih',
         ];
 
         yield [
+            'secret' => 'loooooooooooooooooooooooooooooooooooooooooooooongenoughtestsecret',
             'algorithm' => 'hmac.sha512',
             'subscribe' => [],
             'publish' => ['*'],
             'additionalClaims' => [],
-            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.eK12cNN2fGAaSnFjSYaqTrlKWFtOfKh5ILek_LN-qjG6tGpPKBXGknkQl7a_WrN1PYdgUhw3jPMtpk0HLO6VFA',
+            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOltdfX0.eMSnFpi3G0i0lvM_f55E5vUcxkT1GqyVY7qu7c_mZTjKAh4wX3mIJOGoftX7WQRlE1qTVs0OsJ0qyeyet3Yb-g',
         ];
 
         yield [
+            'secret' => 'looooooooooooongenoughtestsecret',
             'algorithm' => 'hmac.sha256',
             'subscribe' => [],
             'publish' => ['*'],
@@ -139,7 +144,7 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
                     'payload' => ['foo' => 'bar'],
                 ],
             ],
-            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsib3ZlcnJpZGRlbiJdLCJzdWJzY3JpYmUiOlsib3ZlcnJpZGRlbiJdLCJwYXlsb2FkIjp7ImZvbyI6ImJhciJ9fX0.EBddBO8x1UNIiyZLknllC8nvJV7XktOwCKbZbOuerh0',
+            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsib3ZlcnJpZGRlbiJdLCJzdWJzY3JpYmUiOlsib3ZlcnJpZGRlbiJdLCJwYXlsb2FkIjp7ImZvbyI6ImJhciJ9fX0.owz54sSlMuVq2PqtBGFPdrYSXvMKTQc6UQdLEMOlP5s',
         ];
     }
 }


### PR DESCRIPTION
Fixes:

> 2) Symfony\Component\Mercure\Tests\Jwt\LcobucciFactoryTest::testCreate with data set 2 ('hmac.sha512', array(), array('*'), array(), 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIU...LO6VFA')
Lcobucci\JWT\Signer\InvalidKeyProvided: Key provided is shorter than 512 bits, only 256 bits provided

& co