### PR TITLE
feat: Add 'rel=self' Link header to request

### DIFF
--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -41,6 +41,27 @@ final class Discovery
 
         $hubInstance = $this->registry->getHub($hub);
         $link = new Link('mercure', $hubInstance->getPublicUrl());
+
+        $this->addLinkHeader($request, $link);   
+    }
+
+    /**
+     * Add self link header to the given request.
+     */
+    public function addSelfLink(Request $request, ?string $url = null): void
+    {
+        // Prevent issues with NelmioCorsBundle
+        if ($this->isPreflightRequest($request)) {
+            return;
+        }
+
+        $link = new Link('self', $url);
+
+        $this->addLinkHeader($request, $link);   
+    }
+
+    private function addLinkHeader(Request $request, Link $link)
+    {
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set('_links', new GenericLinkProvider([$link]));
 

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -42,7 +42,7 @@ final class Discovery
         $hubInstance = $this->registry->getHub($hub);
         $link = new Link('mercure', $hubInstance->getPublicUrl());
 
-        $this->addLinkHeader($request, $link);   
+        $this->addLinkHeader($request, $link);
     }
 
     /**
@@ -55,16 +55,16 @@ final class Discovery
             return;
         }
 
-        if(null === $url){
+        if (null === $url) {
             $url = $request->getRequestUri();
         }
 
         $link = new Link('self', $url);
 
-        $this->addLinkHeader($request, $link);   
+        $this->addLinkHeader($request, $link);
     }
 
-    private function addLinkHeader(Request $request, Link $link)
+    private function addLinkHeader(Request $request, Link $link): void
     {
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set('_links', new GenericLinkProvider([$link]));

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -55,6 +55,10 @@ final class Discovery
             return;
         }
 
+        if(null === $url){
+            $url = $request->getRequestUri();
+        }
+
         $link = new Link('self', $url);
 
         $this->addLinkHeader($request, $link);   


### PR DESCRIPTION
This PR aims to easily add a new Link header with rel=self.
```php
$discovery->addSelfLink($request, $url);
````
Any value value can be passed as second parameter although according to Mercure specification default value is the current URL of the resource.
The user remains in charge of setting the correct value in case of content-negociation.
The 'adding link' part has been refactored to avoid code duplication.