### PR TITLE
Feat: Security: Allow subsribe and publish topics to be passed as null to token factory

### DIFF
--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -87,7 +87,7 @@ final class Authorization
         }
 
         if ($subscribe !== null) {
-            $subscribe = (array) $publish;
+            $subscribe = (array) $subscribe;
         }
         if ($publish !== null) {
             $publish = (array) $publish;

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -40,8 +40,8 @@ final class Authorization
     /**
      * Sets mercureAuthorization cookie for the given hub.
      *
-     * @param string[]|string      $subscribe        a topic or a list of topics that the authorization cookie will allow subscribing to
-     * @param string[]|string      $publish          a list of topics that the authorization cookie will allow publishing to
+     * @param string[]|string|null $subscribe        a topic or a list of topics that the authorization cookie will allow subscribing to
+     * @param string[]|string|null $publish          a list of topics that the authorization cookie will allow publishing to
      * @param array<string, mixed> $additionalClaims an array of additional claims for the JWT
      * @param string|null          $hub              the hub to generate the cookie for
      */
@@ -63,8 +63,8 @@ final class Authorization
     /**
      * Creates mercureAuthorization cookie for the given hub.
      *
-     * @param string[]|string      $subscribe        a list of topics that the authorization cookie will allow subscribing to
-     * @param string[]|string      $publish          a list of topics that the authorization cookie will allow publishing to
+     * @param string[]|string|null $subscribe        a list of topics that the authorization cookie will allow subscribing to
+     * @param string[]|string|null $publish          a list of topics that the authorization cookie will allow publishing to
      * @param array<string, mixed> $additionalClaims an array of additional claims for the JWT
      * @param string|null          $hub              the hub to generate the cookie for
      */
@@ -86,7 +86,14 @@ final class Authorization
             $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
         }
 
-        $token = $tokenFactory->create((array) $subscribe, (array) $publish, $additionalClaims);
+        if ($subscribe !== null) {
+            $subscribe = (array) $publish;
+        }
+        if ($publish !== null) {
+            $publish = (array) $publish;
+        }
+
+        $token = $tokenFactory->create($subscribe, $publish, $additionalClaims);
         $url = $hubInstance->getPublicUrl();
         /** @var array $urlComponents */
         $urlComponents = parse_url($url);

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -27,14 +27,16 @@ final class Authorization
 
     private $registry;
     private $cookieLifetime;
+    private $cookieSameSite;
 
     /**
      * @param int|null $cookieLifetime in seconds, 0 for the current session, null to default to the value of "session.cookie_lifetime" or 3600 if "session.cookie_lifetime" is set to 0. The "exp" field of the JWT will be set accordingly if not set explicitly, defaults to 1h in case of session cookies.
      */
-    public function __construct(HubRegistry $registry, ?int $cookieLifetime = null)
+    public function __construct(HubRegistry $registry, ?int $cookieLifetime = null, ?string $cookieSameSite = Cookie::SAMESITE_STRICT)
     {
         $this->registry = $registry;
         $this->cookieLifetime = $cookieLifetime ?? (int) \ini_get('session.cookie_lifetime');
+        $this->cookieSameSite = $cookieSameSite;
     }
 
     /**
@@ -111,7 +113,7 @@ final class Authorization
             'http' !== strtolower($urlComponents['scheme'] ?? 'https'),
             true,
             false,
-            Cookie::SAMESITE_STRICT
+            $this->cookieSameSite
         );
     }
 
@@ -135,7 +137,7 @@ final class Authorization
             'http' !== strtolower($urlComponents['scheme'] ?? 'https'),
             true,
             false,
-            Cookie::SAMESITE_STRICT
+            $this->cookieSameSite
         );
     }
 

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -34,7 +34,7 @@ final class Authorization
     public function __construct(HubRegistry $registry, ?int $cookieLifetime = null)
     {
         $this->registry = $registry;
-        $this->cookieLifetime = $cookieLifetime ?? (int) ini_get('session.cookie_lifetime');
+        $this->cookieLifetime = $cookieLifetime ?? (int) \ini_get('session.cookie_lifetime');
     }
 
     /**
@@ -86,10 +86,10 @@ final class Authorization
             $additionalClaims['exp'] = new \DateTimeImmutable(0 === $cookieLifetime ? '+1 hour' : "+{$cookieLifetime} seconds");
         }
 
-        if ($subscribe !== null) {
+        if (null !== $subscribe) {
             $subscribe = (array) $subscribe;
         }
-        if ($publish !== null) {
+        if (null !== $publish) {
             $publish = (array) $publish;
         }
 

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -77,10 +77,10 @@ final class LcobucciFactory implements TokenFactoryInterface
         }
 
         $tokens = [];
-        if ($publish !== null) {
+        if (null !== $publish) {
             $tokens['publish'] = (array) $publish;
         }
-        if ($subscribe !== null) {
+        if (null !== $subscribe) {
             $tokens['subscribe'] = (array) $subscribe;
         }
 

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -68,7 +68,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string
+    public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
     {
         $builder = $this->configurations->builder();
 
@@ -77,11 +77,11 @@ final class LcobucciFactory implements TokenFactoryInterface
         }
 
         $tokens = [];
-        if ($publish) {
-            $tokens['publish'] = $publish;
+        if ($publish !== null) {
+            $tokens['publish'] = (array) $publish;
         }
-        if ($subscribe) {
-            $tokens['subscribe'] = $subscribe;
+        if ($subscribe !== null) {
+            $tokens['subscribe'] = (array) $subscribe;
         }
 
         $additionalClaims['mercure'] = array_merge($tokens, $additionalClaims['mercure'] ?? []);

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -68,7 +68,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string
+    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string
     {
         $builder = $this->configurations->builder();
 
@@ -76,10 +76,15 @@ final class LcobucciFactory implements TokenFactoryInterface
             $additionalClaims['exp'] = new \DateTimeImmutable("+{$this->jwtLifetime} seconds");
         }
 
-        $additionalClaims['mercure'] = array_merge([
-            'publish' => $publish,
-            'subscribe' => $subscribe,
-        ], $additionalClaims['mercure'] ?? []);
+        $tokens = [];
+        if ($publish) {
+            $tokens['publish'] = $publish;
+        }
+        if ($subscribe) {
+            $tokens['subscribe'] = $subscribe;
+        }
+
+        $additionalClaims['mercure'] = array_merge($tokens, $additionalClaims['mercure'] ?? []);
 
         foreach ($additionalClaims as $name => $value) {
             switch ($name) {

--- a/src/Jwt/LcobucciFactory.php
+++ b/src/Jwt/LcobucciFactory.php
@@ -68,7 +68,7 @@ final class LcobucciFactory implements TokenFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
+    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string
     {
         $builder = $this->configurations->builder();
 

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,9 +23,9 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[]|null $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[]|null $publish          a list of topics that the token will allow publishing to
-     * @param mixed[]       $additionalClaims an array of additional claims for the JWT
+     * @param string[]|string|null $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|string|null $publish          a list of topics that the token will allow publishing to
+     * @param mixed[]              $additionalClaims an array of additional claims for the JWT
      */
-    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;
+    public function create($subscribe = [], $publish = [], array $additionalClaims = []): string;
 }

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,9 +23,9 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[]|null   $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[]|null   $publish          a list of topics that the token will allow publishing to
-     * @param mixed[]         $additionalClaims an array of additional claims for the JWT
+     * @param string[]|null $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|null $publish          a list of topics that the token will allow publishing to
+     * @param mixed[]       $additionalClaims an array of additional claims for the JWT
      */
     public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;
 }

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,8 +23,8 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[]|string|null $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[]|string|null $publish          a list of topics that the token will allow publishing to
+     * @param string[]|string      $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|string      $publish          a list of topics that the token will allow publishing to
      * @param mixed[]              $additionalClaims an array of additional claims for the JWT
      */
     public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,9 +23,9 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[] $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[] $publish          a list of topics that the token will allow publishing to
-     * @param mixed[]  $additionalClaims an array of additional claims for the JWT
+     * @param string[]|null $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|null $publish          a list of topics that the token will allow publishing to
+     * @param mixed[]       $additionalClaims an array of additional claims for the JWT
      */
-    public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string;
+    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;
 }

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,8 +23,8 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[]|string $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[]|string $publish          a list of topics that the token will allow publishing to
+     * @param string[]|null   $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|null   $publish          a list of topics that the token will allow publishing to
      * @param mixed[]         $additionalClaims an array of additional claims for the JWT
      */
     public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -23,9 +23,9 @@ interface TokenFactoryInterface
     /**
      * Create a token that allows publishing to $publish and subscribing to $subscribe.
      *
-     * @param string[]|string      $subscribe        a list of topics that the token will allow subscribing to
-     * @param string[]|string      $publish          a list of topics that the token will allow publishing to
-     * @param mixed[]              $additionalClaims an array of additional claims for the JWT
+     * @param string[]|string $subscribe        a list of topics that the token will allow subscribing to
+     * @param string[]|string $publish          a list of topics that the token will allow publishing to
+     * @param mixed[]         $additionalClaims an array of additional claims for the JWT
      */
     public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;
 }

--- a/src/Jwt/TokenFactoryInterface.php
+++ b/src/Jwt/TokenFactoryInterface.php
@@ -27,5 +27,5 @@ interface TokenFactoryInterface
      * @param string[]|string|null $publish          a list of topics that the token will allow publishing to
      * @param mixed[]              $additionalClaims an array of additional claims for the JWT
      */
-    public function create($subscribe = [], $publish = [], array $additionalClaims = []): string;
+    public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string;
 }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -83,7 +83,7 @@ class AuthorizationTest extends TestCase
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
             new class() implements TokenFactoryInterface {
-                public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
+                public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string
                 {
                     return '';
                 }
@@ -170,7 +170,7 @@ class AuthorizationTest extends TestCase
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
             new class() implements TokenFactoryInterface {
-                public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
+                public function create(?array $subscribe = [], ?array $publish = [], array $additionalClaims = []): string
                 {
                     return '';
                 }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Mercure\Tests;
 
 use Lcobucci\JWT\Signer\Key\InMemory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\Authorization;
 use Symfony\Component\Mercure\Exception\RuntimeException;
@@ -68,12 +69,13 @@ class AuthorizationTest extends TestCase
         ));
 
         $request = Request::create('https://example.com');
-        $authorization = new Authorization($registry, 0);
+        $authorization = new Authorization($registry, 0, Cookie::SAMESITE_LAX);
         $authorization->setCookie($request, ['foo'], ['bar'], ['x-foo' => 'bar']);
 
         $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
         $this->assertNotNull($cookie->getValue());
         $this->assertSame(0, $cookie->getExpiresTime());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookie->getSameSite());
     }
 
     public function testClearCookie(): void

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -183,28 +183,27 @@ class AuthorizationTest extends TestCase
         $authorization->clearCookie($request);
     }
 
-//    public function testSetNullCookieTopics(): void
-//    {
-//        $tokenFactory = $this->createMock(TokenFactoryInterface::class);
-//        $tokenFactory
-//            ->expects($this->once())
-//            ->method('create')
-//            ->with($this->equalTo(['foo']), $this->equalTo(['bar']), $this->arrayHasKey('x-foo'))
-//        ;
-//
-//        $registry = new HubRegistry(new MockHub(
-//            'https://example.com/.well-known/mercure',
-//            new StaticTokenProvider('foo.bar.baz'),
-//            function (Update $u): string { return 'dummy'; },
-//            $tokenFactory
-//        ));
-//
-//        $request = Request::create('https://example.com');
-//        $authorization = new Authorization($registry, 0);
-//        $authorization->setCookie($request, ['foo'], ['bar'], ['x-foo' => 'bar']);
-//
-//        $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
-//        $this->assertNotNull($cookie->getValue());
-//        $this->assertSame(0, $cookie->getExpiresTime());
-//    }
+    public function testSetNullCookieTopics(): void
+    {
+        $tokenFactory = $this->createMock(TokenFactoryInterface::class);
+        $tokenFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->isNull(), $this->isNull(), $this->arrayHasKey('x-foo'))
+        ;
+
+        $registry = new HubRegistry(new MockHub(
+            'https://example.com/.well-known/mercure',
+            new StaticTokenProvider('foo.bar.baz'),
+            function (Update $u): string { return 'dummy'; },
+            $tokenFactory
+        ));
+
+        $request = Request::create('https://example.com');
+        $authorization = new Authorization($registry);
+        $authorization->setCookie($request, null, null, ['x-foo' => 'bar']);
+
+        $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
+        $this->assertNotNull($cookie->getValue());
+    }
 }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -83,7 +83,7 @@ class AuthorizationTest extends TestCase
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
             new class() implements TokenFactoryInterface {
-                public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string
+                public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
                 {
                     return '';
                 }
@@ -170,7 +170,7 @@ class AuthorizationTest extends TestCase
             new StaticTokenProvider('foo.bar.baz'),
             function (Update $u): string { return 'dummy'; },
             new class() implements TokenFactoryInterface {
-                public function create(array $subscribe = [], array $publish = [], array $additionalClaims = []): string
+                public function create($subscribe = [], $publish = [], array $additionalClaims = []): string
                 {
                     return '';
                 }
@@ -182,4 +182,29 @@ class AuthorizationTest extends TestCase
         $authorization->setCookie($request);
         $authorization->clearCookie($request);
     }
+
+//    public function testSetNullCookieTopics(): void
+//    {
+//        $tokenFactory = $this->createMock(TokenFactoryInterface::class);
+//        $tokenFactory
+//            ->expects($this->once())
+//            ->method('create')
+//            ->with($this->equalTo(['foo']), $this->equalTo(['bar']), $this->arrayHasKey('x-foo'))
+//        ;
+//
+//        $registry = new HubRegistry(new MockHub(
+//            'https://example.com/.well-known/mercure',
+//            new StaticTokenProvider('foo.bar.baz'),
+//            function (Update $u): string { return 'dummy'; },
+//            $tokenFactory
+//        ));
+//
+//        $request = Request::create('https://example.com');
+//        $authorization = new Authorization($registry, 0);
+//        $authorization->setCookie($request, ['foo'], ['bar'], ['x-foo' => 'bar']);
+//
+//        $cookie = $request->attributes->get('_mercure_authorization_cookies')[null];
+//        $this->assertNotNull($cookie->getValue());
+//        $this->assertSame(0, $cookie->getExpiresTime());
+//    }
 }

--- a/tests/Jwt/LcobucciFactoryTest.php
+++ b/tests/Jwt/LcobucciFactoryTest.php
@@ -67,7 +67,7 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
     /**
      * @dataProvider provideCreateCases
      */
-    public function testCreate(string $secret, string $algorithm, array $subscribe, array $publish, array $additionalClaims, string $expectedJwt): void
+    public function testCreate(string $secret, string $algorithm, ?array $subscribe, ?array $publish, array $additionalClaims, string $expectedJwt): void
     {
         \assert('' !== $secret);
         $factory = new LcobucciFactory($secret, $algorithm, null);
@@ -105,6 +105,15 @@ TZCHmg89ySLBfCAspVeo63o/R7bs9a7BP9x2h5uwCBogSvkEwhhPKnboVN45bp9c
 
     public function provideCreateCases(): iterable
     {
+        yield [
+            'secret' => 'looooooooooooongenoughtestsecret',
+            'algorithm' => 'hmac.sha256',
+            'subscribe' => null,
+            'publish' => null,
+            'additionalClaims' => [],
+            'expectedJwt' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjpbXX0.V7YsSEFCPfzyvt38oIID7b9iE4NYjfcV07CxPUyBeLk',
+        ];
+
         yield [
             'secret' => 'looooooooooooongenoughtestsecret',
             'algorithm' => 'hmac.sha256',


### PR DESCRIPTION
I believe this addresses
Fix: https://github.com/symfony/mercure/issues/80
Fix: https://github.com/symfony/mercure/issues/92