### PR TITLE
add changelog for version 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+0.6.2
+-----
+
+* Always set the `Content-Type` HTTP header to `application/x-www-form-urlencoded` when sending an update to the hub
+* `Symfony\Component\Mercure\Messenger\UpdateHandler` now returns the ID of the published update
+* Allow passing `null` as `$subscribe` and `$publish` parameters in `Symfony\Component\Mercure\Jwt\TokenFactoryInterface`
+* Add a new optional parameter in `Symfony\Component\Mercure\Authorization::__construct()` to set the `SameSite` cookie attribute
+
 0.6.1
 -----
 


### PR DESCRIPTION
https://github.com/symfony/mercure/pull/93/files#diff-9f0385fe6a7fd9840e8e4c727283cca2a47edd0c0a9d2c74bcaf55a9c174700bR30 is probably a tiny BC break, but it should not impact many users (this class is mostly internal), and it's allowed by semver as we're still in 0.x.