### PR TITLE
Apply breaking CS from fabbot

### DIFF
--- a/src/Twig/MercureExtension.php
+++ b/src/Twig/MercureExtension.php
@@ -30,7 +30,7 @@ final class MercureExtension extends AbstractExtension
     private $authorization;
     private $requestStack;
 
-    public function __construct(HubRegistry $hubRegistry, ?Authorization $authorization = null, ?RequestStack $requestStack = null)
+    public function __construct(HubRegistry $hubRegistry, Authorization $authorization = null, RequestStack $requestStack = null)
     {
         $this->hubRegistry = $hubRegistry;
         $this->authorization = $authorization;
@@ -68,11 +68,11 @@ final class MercureExtension extends AbstractExtension
         }
 
         if (
-            null === $this->authorization ||
-            null === $this->requestStack ||
-            (!isset($options['subscribe']) && !isset($options['publish']) && !isset($options['additionalClaims'])) ||
+            null === $this->authorization
+            || null === $this->requestStack
+            || (!isset($options['subscribe']) && !isset($options['publish']) && !isset($options['additionalClaims']))
             /* @phpstan-ignore-next-line */
-            null === $request = method_exists($this->requestStack, 'getMainRequest') ? $this->requestStack->getMainRequest() : $this->requestStack->getMasterRequest()
+            || null === $request = method_exists($this->requestStack, 'getMainRequest') ? $this->requestStack->getMainRequest() : $this->requestStack->getMasterRequest()
         ) {
             return $url;
         }


### PR DESCRIPTION
See breaking CI in https://github.com/symfony/mercure/pull/106


More info: https://fabbot.io/report/symfony/mercure/106/65f299282349dc83b235cbb269531c824b5860b4

```
curl https://fabbot.io/patch/symfony/mercure/106/65f299282349dc83b235cbb269531c824b5860b4/cs.diff | patch -p0
```