### PR TITLE
fix compatibility of last event ID with the latest version of the spec

### DIFF
--- a/src/Twig/MercureExtension.php
+++ b/src/Twig/MercureExtension.php
@@ -64,7 +64,9 @@ final class MercureExtension extends AbstractExtension
         }
 
         if ('' !== ($options['lastEventId'] ?? '')) {
-            $url .= '&Last-Event-ID='.rawurlencode($options['lastEventId']);
+            $encodedLastEventId = rawurlencode($options['lastEventId']);
+            // Last-Event-ID is kept for compatibility with older versions of the protocol: https://mercure.rocks/docs/UPGRADE#0-14
+            $url .= "&lastEventID=$encodedLastEventId&Last-Event-ID=$encodedLastEventId";
         }
 
         if (

--- a/tests/Twig/MercureExtensionTest.php
+++ b/tests/Twig/MercureExtensionTest.php
@@ -72,6 +72,6 @@ class MercureExtensionTest extends TestCase
             'lastEventId' => 'urn:uuid:13697bc5-e3c6-48cf-99c8-9d64c26f1a2f',
         ]);
 
-        $this->assertSame('https://example.com/.well-known/mercure?topic=https%3A%2F%2Ffoo%2Fbar&Last-Event-ID=urn%3Auuid%3A13697bc5-e3c6-48cf-99c8-9d64c26f1a2f', $url);
+        $this->assertSame('https://example.com/.well-known/mercure?topic=https%3A%2F%2Ffoo%2Fbar&lastEventID=urn%3Auuid%3A13697bc5-e3c6-48cf-99c8-9d64c26f1a2f&Last-Event-ID=urn%3Auuid%3A13697bc5-e3c6-48cf-99c8-9d64c26f1a2f', $url);
     }
 }


### PR DESCRIPTION
Closes https://github.com/symfony/mercure/issues/112.