### PR TITLE
Update Update.php: Adding phpdoc

### DIFF
--- a/src/Update.php
+++ b/src/Update.php
@@ -34,7 +34,7 @@ final class Update
 
     /**
      * @param string|string[] $topics
-     * @param ?string $type SEE type: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
+     * @param ?string $type SSE type: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
      */
     public function __construct($topics, string $data = '', bool $private = false, ?string $id = null, ?string $type = null, ?int $retry = null)
     {

--- a/src/Update.php
+++ b/src/Update.php
@@ -34,6 +34,7 @@ final class Update
 
     /**
      * @param string|string[] $topics
+     * @param ?string $type SEE type: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
      */
     public function __construct($topics, string $data = '', bool $private = false, ?string $id = null, ?string $type = null, ?int $retry = null)
     {


### PR DESCRIPTION
Info is taken from https://github.com/symfony/symfony-docs/issues/20574#issuecomment-2597893282

Why is the default value `null` and not `message`?